### PR TITLE
Change jira issue key regex to allow number in project key

### DIFF
--- a/src/issue-key.ts
+++ b/src/issue-key.ts
@@ -3,7 +3,7 @@ import { logger } from "./logger";
 import { IssueKey, TogglTimeEntry } from "./types";
 import { prompt } from "./utils";
 
-export const ISSUE_KEY_REGEX = /^[A-Z]+-[0-9]+/; // e.g. ABC-123
+export const ISSUE_KEY_REGEX = /^[A-Z0-9]+-[0-9]+/; // e.g. ABC-123
 
 export async function getIssueKey(
   timeEntry: TogglTimeEntry


### PR DESCRIPTION
Updated the issue key regular expression to allow project keys containing numbers (e.g., CC3, NF2), in line with JIRA’s capabilities. This change ensures that the application properly supports project keys that include digits.