### PR TITLE
Fix rounding interval log to display minutes instead of seconds

### DIFF
--- a/src/command-sync.ts
+++ b/src/command-sync.ts
@@ -152,7 +152,7 @@ const commandSync = async (argv: SyncCommandArgs) => {
           logger.warn(
             `${issueKey} (${formatTime(
               entry.duration
-            )}) can be rounded to nearest ${interval} minutes`
+            )}) can be rounded to nearest ${interval / 60} minutes`
           );
           const roundingAnswer = await promptKeypress(
             `Round (u)p, (d)own, (n)earest or empty to skip rounding: `,


### PR DESCRIPTION
This PR fixes the log output for the rounding interval. Previously, the interval was displayed in seconds, causing confusion (e.g., "nearest 300 minutes" instead of "nearest 5 minutes" for a 5-minute interval). The message now correctly shows the interval in minutes, matching the configuration value.